### PR TITLE
Adds Metadata Update Functionality

### DIFF
--- a/src/jobs/process-blockchain-events.js
+++ b/src/jobs/process-blockchain-events.js
@@ -120,6 +120,10 @@ export default {
 
                   }
 
+                  case 'Modified':
+                    promise = codexTitleService.modify(...returnValues)
+                    break
+
                   case 'Approval':
                     promise = codexTitleService.approveAddress(...returnValues)
                     break

--- a/src/jobs/remove-orphaned-metadata.js
+++ b/src/jobs/remove-orphaned-metadata.js
@@ -70,6 +70,7 @@ export default {
               return models.CodexTitleFile
                 .remove(removeMetadataFilesConditions)
                 .then(() => {
+                  // TODO: remove old pendingUpdates here?
                   return metadatum.remove()
                 })
 

--- a/src/models/codex-title-metadata-pending-update.js
+++ b/src/models/codex-title-metadata-pending-update.js
@@ -1,0 +1,118 @@
+import mongoose from 'mongoose'
+import { web3 } from '@codex-protocol/ethereum-service'
+
+import mongooseService from '../services/mongoose'
+
+const schemaOptions = {
+  timestamps: true, // let mongoose handle the createdAt and updatedAt fields
+  usePushEach: true, // see https://github.com/Automattic/mongoose/issues/5574
+}
+
+const schema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+  },
+  nameHash: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+    default: null,
+  },
+  descriptionHash: {
+    type: String,
+    default: null,
+  },
+  mainImage: {
+    required: true,
+    ref: 'CodexTitleFile',
+    type: mongoose.Schema.Types.ObjectId,
+  },
+  images: [{
+    ref: 'CodexTitleFile',
+    type: mongoose.Schema.Types.ObjectId,
+  }],
+  files: [{
+    ref: 'CodexTitleFile',
+    type: mongoose.Schema.Types.ObjectId,
+  }],
+}, schemaOptions)
+
+schema.virtual('fileHashes').get(function getFileHashes() {
+  return [
+    this.mainImage.hash,
+    ...this.images.map((image) => { return image.hash }),
+    ...this.files.map((file) => { return file.hash }),
+  ]
+})
+
+schema.set('toObject', {
+  virtuals: true,
+})
+
+schema.set('toJSON', {
+  getters: true, // essentially converts _id to just id
+  virtuals: true,
+  versionKey: false,
+  transform(document, transformedDocument) {
+
+    // remove some mongo-specicic keys that aren't necessary to send in
+    //  responses
+    delete transformedDocument._id
+
+    // remove any populations if they weren't populated, since they'll just be
+    //  ObjectIds otherwise and that might expose too much information to
+    //  someone who isn't allowed to view that data
+    //
+    // NOTE: instead of deleting keys, we'll just pretend they're empty, that
+    //  way the front end can always assume the keys will be present
+    if (document.mainImage && !document.populated('mainImage')) {
+      // delete transformedDocument.mainImage
+      transformedDocument.mainImage = null
+    }
+
+    if (document.images.length > 0 && !document.populated('images')) {
+      // delete transformedDocument.images
+      transformedDocument.images = []
+    }
+
+    if (document.files.length > 0 && !document.populated('files')) {
+      // delete transformedDocument.files
+      transformedDocument.files = []
+    }
+
+    return transformedDocument
+
+  },
+})
+
+// always get images & files
+function populate(next) {
+  this.populate('mainImage images files')
+  next()
+}
+
+schema.pre('find', populate)
+schema.pre('findOne', populate)
+schema.pre('findOneAndUpdate', populate)
+
+// set hashes when their unhashed counterparts are set
+function setHashesBeforeValidation(next) {
+  this.nameHash = web3.utils.soliditySha3(this.name)
+  this.descriptionHash = this.description ? web3.utils.soliditySha3(this.description) : null
+  next()
+}
+
+schema.pre('validate', setHashesBeforeValidation)
+
+// unless an ID is specified in the bulk update query, there's no way to
+//  update the parent CodexTitle records without first running the query and
+//  grabbing all matching IDs... and if an ID is passed, then why not just
+//  find & save?
+schema.pre('update', (next) => {
+  return next(new Error('Bulk updating metadata is not supported as it has some tricky implications with updating hashes on the parent CodexTitleMetadata record. Please find & save instead.'))
+})
+
+export default mongooseService.codexRegistry.model('CodexTitleMetadataPendingUpdate', schema)

--- a/src/models/codex-title.js
+++ b/src/models/codex-title.js
@@ -101,6 +101,10 @@ schema.methods.maskOwnerOnlyFields = function maskOwnerOnlyFields(userAddress) {
 
   this.whitelistedAddresses = []
 
+  if (this.populated('metadata')) {
+    this.metadata.depopulate('pendingUpdates')
+  }
+
   // TODO: mask historical provenance here when that's implemented
   // TODO: rename provenance to digitalProvenance?
   // this.depopulate('historicalProvenance')

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,3 +1,4 @@
+import CodexTitleMetadataPendingUpdate from './codex-title-metadata-pending-update'
 import CodexTitleTransferEvent from './codex-title-transfer-event'
 import CodexTitleMetadata from './codex-title-metadata'
 import BlockchainEvent from './blockchain-event'
@@ -8,6 +9,7 @@ import User from './user'
 import Job from './job'
 
 export default {
+  CodexTitleMetadataPendingUpdate,
   CodexTitleTransferEvent,
   CodexTitleMetadata,
   BlockchainEvent,

--- a/src/routes/user/title/metadata/update.js
+++ b/src/routes/user/title/metadata/update.js
@@ -72,10 +72,7 @@ export default {
           })
           .then(() => {
             codexTitle.metadata.pendingUpdates.push(newPendingUpdate)
-            return codexTitle.metadata.save()
-          })
-          .then(() => {
-            return codexTitle.metadata.generateModifyMetadataHashesTransactionData(newPendingUpdate)
+            return codexTitle.metadata.save() // TODO: should this route just return newPendingUpdate only?
           })
 
       })

--- a/src/routes/user/title/metadata/update.js
+++ b/src/routes/user/title/metadata/update.js
@@ -1,0 +1,85 @@
+import Joi from 'joi'
+import RestifyErrors from 'restify-errors'
+
+import models from '../../../../models'
+
+const fileSchema = Joi.object().keys({
+  _id: Joi.string().regex(/^[0-9a-f]{24}$/i).required(),
+}).rename('id', '_id')
+
+export default {
+
+  method: 'put',
+  path: '/users?/titles?/:tokenId/metadata',
+
+  requireAuthentication: true,
+
+  parameters: Joi.object().keys({
+    description: Joi.string().allow(null),
+    mainImage: fileSchema,
+    name: Joi.string(),
+    images: Joi.array().items(
+      fileSchema,
+    ).single(),
+    files: Joi.array().items(
+      fileSchema,
+    ).single(),
+  }).or(
+    'description',
+    'mainImage',
+    'images',
+    'files',
+    'name',
+  ),
+
+  handler(request, response) {
+
+    const conditions = {
+      _id: request.params.tokenId,
+      ownerAddress: response.locals.userAddress,
+    }
+
+    return models.CodexTitle.findOne(conditions)
+      .populate('metadata')
+      .then((codexTitle) => {
+
+        if (!codexTitle) {
+          throw new RestifyErrors.NotFoundError(`CodexTitle with tokenId ${request.params.tokenId} does not exist.`)
+        }
+
+        const newPendingUpdateData = Object.assign({}, codexTitle.metadata.toObject(), request.parameters)
+
+        // delete some things we don't really want to copy over because they'll
+        //  get set independently by mongoose
+        delete newPendingUpdateData.updatedAt
+        delete newPendingUpdateData.createdAt
+        delete newPendingUpdateData._id
+
+        // remove the main image from the images array if it exists in both places
+        newPendingUpdateData.images = newPendingUpdateData.images.filter((image) => {
+          return image._id !== newPendingUpdateData.mainImage._id
+        })
+
+        // TODO: dedupe pendingUpdates to make sure that two of the exact same
+        //  updates aren't saved?
+        const newPendingUpdate = new models.CodexTitleMetadataPendingUpdate(newPendingUpdateData)
+
+        return newPendingUpdate.save()
+          .then(() => {
+            return newPendingUpdate
+              .populate('mainImage images files') // TODO: move this to a post-save hook (but check that they haven't been populated already)
+              .execPopulate()
+          })
+          .then(() => {
+            codexTitle.metadata.pendingUpdates.push(newPendingUpdate)
+            return codexTitle.metadata.save()
+          })
+          .then(() => {
+            return codexTitle.metadata.generateModifyMetadataHashesTransactionData(newPendingUpdate)
+          })
+
+      })
+
+  },
+
+}


### PR DESCRIPTION
### Background
Updating metadata is an essential step in the lifecycle of a Codex Record, whether it's adding a new images, attaching historical provenance (arbitrary files), or simply changing the description. From the front-end perspective, this is necessarily a two-step process:

1. Issue an API call to create a new "pending update" record. The payload you send to the API will be the new "raw" data (and not the hashes you'll send to the blockchain in the next step.)
2. Submit a transaction to the blockchain that invokes the [Codex Registry contract](https://github.com/codex-protocol/contract.codex-registry)'s `modifyMetadataHashes` function. The transaction data you send should include hashes of all the new data that represents the intended state after the update.

After the transaction is mined, the `Modified` event is emitted and [EEL](https://github.com/codex-protocol/service.eel) will index the event. The API will then process that event by looking up the metadata record, choosing the matching "pending update" record, and committing those changes to the actual metadata record.


### Updates
- Added new `CodexTitleMetadataPendingUpdate` model (the `CodexTitleMetadata` model now has an array of these models saved under `pendingUpdates`)
- Both `CodexTitleMetadata` & `CodexTitleMetadataPendingUpdate` have a new virtual property `fileHashes`, which aggregates the hashes for `mainImage`, `images` (supplemental images), and `files` ("historical provenance" / arbitrary documents)
- `CodexTitleMetadata` has a new virtual property `hasPendingUpdates`, which is a boolean flag that lets you easily indicate that a Record is pending update. **This is useful because the `pendingUpdates` array is only returned for the owner of a Record.**


### Usage
1. To create a new pendingUpdate entry, send an authenticated request to the API:

  ```
  PUT /users/titles/:tokenId/metadata

  {
    "name": "New Name for this Codex Record",
    "description": "New description",
    "mainImage": { "id": "<CodexTitleFile.id>" },
    "images": [
      { "id": "<CodexTitleFile.id>" },
      { "id": "<CodexTitleFile.id>" }
    ],
    "files": [
      { "id": "<CodexTitleFile.id>" },
      { "id": "<CodexTitleFile.id>" },
      { "id": "<CodexTitleFile.id>" }
    ],
  }
  ```

  Some notes:
    - You may omit any field to leave data unchanged
    - If you specify the same CodexTitleFile record in the `images` array and as the `mainImage`, it will be removed from the `images` array
    - You will get the updated CodexTitleMetadata record back, including the new pending update record in the `pendingUpdates` array (maybe this route should just return the new CodexTitleMetadataPendingUpdate record only?)

2. Send a transaction to the CodexTitle contract:

```javascript

const modifyMetadataHashesArguments = [
  codexTitle.id,
  codexTitle.metadata.pendingUpdates[0].nameHash,
  codexTitle.metadata.pendingUpdates[0].descriptionHash || '',
  codexTitle.metadata.pendingUpdates[0].fileHashes,
  '1',
  codexTitle.metadata.id,
]

CodexTitle.methods.modifyMetadataHashes(modifyMetadataHashesArguments).call()
```

Note that you *should probably NOT* read the hashes from the API response, and you should calculate them yourself on the frontend. This keeps things "dappy" and reduces the need for the frontend to "trust" the backend.

### Future Work
- [ ] Create digital provenance entries to track changes to metadata over time
- [ ] Add separate privacy settings for "historical provenance" / arbitrary documents 
- [ ] Delete removed files from S3? 🤔