### PR TITLE
Add Secondary Privacy Controls for Historical Provenance

### DIFF
--- a/src/models/codex-record-metadata.js
+++ b/src/models/codex-record-metadata.js
@@ -56,7 +56,7 @@ const schema = new mongoose.Schema({
   files: [{
     ref: 'CodexRecordFile',
     type: mongoose.Schema.Types.ObjectId,
-    permissions: ['approved-unless-historical-provenance-is-private'],
+    permissions: ['approved-unless-historical-provenance-is-public'],
   }],
   pendingUpdates: [{
     permissions: ['owner'],

--- a/src/models/codex-record-metadata.js
+++ b/src/models/codex-record-metadata.js
@@ -55,13 +55,13 @@ const schema = new mongoose.Schema({
   }],
   files: [{
     ref: 'CodexRecordFile',
-    permissions: ['approved'],
     type: mongoose.Schema.Types.ObjectId,
+    permissions: ['approved-unless-historical-provenance-is-private'],
   }],
   pendingUpdates: [{
     permissions: ['owner'],
-    ref: 'CodexRecordMetadataPendingUpdate',
     type: mongoose.Schema.Types.ObjectId,
+    ref: 'CodexRecordMetadataPendingUpdate',
   }],
 }, schemaOptions)
 

--- a/src/models/codex-record.js
+++ b/src/models/codex-record.js
@@ -127,7 +127,7 @@ schema.set('toJSON', {
       //  false positives
       if (!userAddress || !approvedAddresses.includes(userAddress)) {
         if (document.isPrivate) permissionsToApply.push('approved')
-        if (document.isHistoricalProvenancePrivate) permissionsToApply.push('approved-unless-historical-provenance-is-private')
+        if (document.isHistoricalProvenancePrivate) permissionsToApply.push('approved-unless-historical-provenance-is-public')
       }
 
       if (userAddress !== document.ownerAddress) {

--- a/src/models/codex-record.js
+++ b/src/models/codex-record.js
@@ -60,6 +60,10 @@ const schema = new mongoose.Schema({
     type: Boolean,
     default: true,
   },
+  isHistoricalProvenancePrivate: {
+    type: Boolean,
+    default: true,
+  },
   // has this Record been ignored by the approvedAddress? this essentially just
   //  hides it from the frontend "incoming transfer" view and has no real
   //  correlation to anything in the smart contract
@@ -121,8 +125,9 @@ schema.set('toJSON', {
       // @NOTE: userAddress could be null, and document.approvedAddress could be
       //  null, so we must explicity check if userAddress is null first to avoid
       //  false positives
-      if (document.isPrivate && (!userAddress || !approvedAddresses.includes(userAddress))) {
-        permissionsToApply.push('approved')
+      if (!userAddress || !approvedAddresses.includes(userAddress)) {
+        if (document.isPrivate) permissionsToApply.push('approved')
+        if (document.isHistoricalProvenancePrivate) permissionsToApply.push('approved-unless-historical-provenance-is-private')
       }
 
       if (userAddress !== document.ownerAddress) {

--- a/src/routes/user/record/update.js
+++ b/src/routes/user/record/update.js
@@ -13,12 +13,14 @@ export default {
 
   parameters: Joi.object().keys({
     isPrivate: Joi.boolean(),
+    isHistoricalProvenancePrivate: Joi.boolean(),
     whitelistedAddresses: Joi.array().items(
       Joi.string().regex(/^0x[0-9a-f]{40}$/i, 'ethereum address').lowercase(),
     ).unique(),
   }).or(
     'isPrivate',
     'whitelistedAddresses',
+    'isHistoricalProvenancePrivate',
   ),
 
   handler(request, response) {


### PR DESCRIPTION
This PR adds functionality to the API to allow users to make a Codex Record's "historical provenance" (i.e. the `files` array) private, separately from the ability to make the entire Codex Record private.

The use case here is that you may want to share a Codex Record publicly, but you don't want sensitive information (e.g. appraisal documents) stored in the historical provenance to be visible. Note that explicitly "approved" addresses will be able to see the historical provenance just like the owner.

Note: you can't actually use the front end to populate a Codex Record's historical provenance at the moment. I tested this directly with Postman and it seems to work fine 👍