### PR TITLE
Update Event Handlers to Match Smart Contract "providerData" Changes

### DIFF
--- a/src/models/codex-record-metadata.js
+++ b/src/models/codex-record-metadata.js
@@ -109,7 +109,7 @@ schema.set('toJSON', {
 schema.methods.generateMintTransactionData = function generateMintTransactionData() {
 
   // @TODO: sort out proper provider ID functionality
-  const providerData = codexRecordService.encodeProviderData([
+  const additionalData = codexRecordService.encodeAdditionalData([
     '1', // providerId
     this.id, // providerMetadataId
   ])
@@ -119,7 +119,7 @@ schema.methods.generateMintTransactionData = function generateMintTransactionDat
     this.nameHash,
     this.descriptionHash || nullDescriptionHash,
     this.fileHashes,
-    providerData,
+    additionalData,
   ]
 
   return {
@@ -136,7 +136,7 @@ schema.methods.generateModifyMetadataHashesTransactionData = function generateMo
   }
 
   // @TODO: sort out proper provider ID functionality
-  const providerData = codexRecordService.encodeProviderData([
+  const additionalData = codexRecordService.encodeAdditionalData([
     '1', // providerId
     this.id, // providerMetadataId
   ])
@@ -146,7 +146,7 @@ schema.methods.generateModifyMetadataHashesTransactionData = function generateMo
     pendingUpdate.nameHash,
     pendingUpdate.descriptionHash || nullDescriptionHash,
     pendingUpdate.fileHashes,
-    providerData,
+    additionalData,
   ]
 
   return {

--- a/src/models/codex-record-metadata.js
+++ b/src/models/codex-record-metadata.js
@@ -8,6 +8,8 @@ import models from '../models'
 import mongooseService from '../services/mongoose'
 import codexRecordService from '../services/codex-record'
 
+const nullDescriptionHash = `0x${new Array(64).fill(0).join('')}`
+
 const schemaOptions = {
   timestamps: true, // let mongoose handle the createdAt and updatedAt fields
   usePushEach: true, // see https://github.com/Automattic/mongoose/issues/5574
@@ -115,7 +117,7 @@ schema.methods.generateMintTransactionData = function generateMintTransactionDat
   const mintArguments = [
     this.creatorAddress,
     this.nameHash,
-    this.descriptionHash || '',
+    this.descriptionHash || nullDescriptionHash,
     this.fileHashes,
     providerData,
   ]
@@ -142,7 +144,7 @@ schema.methods.generateModifyMetadataHashesTransactionData = function generateMo
   const modifyMetadataHashesArguments = [
     this.codexRecordTokenId,
     pendingUpdate.nameHash,
-    pendingUpdate.descriptionHash || '',
+    pendingUpdate.descriptionHash || nullDescriptionHash,
     pendingUpdate.fileHashes,
     providerData,
   ]

--- a/src/models/codex-record-metadata.js
+++ b/src/models/codex-record-metadata.js
@@ -6,6 +6,7 @@ import {
 
 import models from '../models'
 import mongooseService from '../services/mongoose'
+import codexRecordService from '../services/codex-record'
 
 const schemaOptions = {
   timestamps: true, // let mongoose handle the createdAt and updatedAt fields
@@ -105,13 +106,18 @@ schema.set('toJSON', {
 
 schema.methods.generateMintTransactionData = function generateMintTransactionData() {
 
+  // @TODO: sort out proper provider ID functionality
+  const providerData = codexRecordService.encodeProviderData([
+    '1', // providerId
+    this.id, // providerMetadataId
+  ])
+
   const mintArguments = [
     this.creatorAddress,
     this.nameHash,
     this.descriptionHash || '',
     this.fileHashes,
-    '1', // @TODO: sort out proper provider ID functionality
-    this.id,
+    providerData,
   ]
 
   return {
@@ -127,13 +133,18 @@ schema.methods.generateModifyMetadataHashesTransactionData = function generateMo
     throw new Error('generateModifyMetadataHashesTransactionData could not be called because a pendingUpdate was not specified.')
   }
 
+  // @TODO: sort out proper provider ID functionality
+  const providerData = codexRecordService.encodeProviderData([
+    '1', // providerId
+    this.id, // providerMetadataId
+  ])
+
   const modifyMetadataHashesArguments = [
     this.codexRecordTokenId,
     pendingUpdate.nameHash,
     pendingUpdate.descriptionHash || '',
     pendingUpdate.fileHashes,
-    '1', // @TODO: sort out proper provider ID functionality
-    this.id,
+    providerData,
   ]
 
   return {


### PR DESCRIPTION
This PR adds the associated changes to support [PR #30](https://github.com/codex-protocol/contract.codex-registry/pull/30) in the `contract.codex-registry` repo.

Instead of expecting `providerId` and `providerMetadataId` as separate parameters in the `confirmMint()` and `modify()` event handlers, we now deserialize both parameters from a single string.