### PR TITLE
Add Provider Functionality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,16 @@
 
 # [REQUIRED]
 #
+# this should be the _id of "your" provider in the database (i.e. the providerId
+#  to send to the smart contract that designates CodexRecords that have metadata
+#  retrievable via your API instance)
+#
+# if you don't have a provider record in the database, send a POST request to
+#  /admin/provider (see: src/routes/admin/provider/create.js)
+METADATA_PROVIDER_ID=
+
+# [REQUIRED]
+#
 # this is used to sign & verify JSON Web Tokens, can be any string you want
 JWT_SECRET=
 

--- a/src/models/codex-record-metadata.js
+++ b/src/models/codex-record-metadata.js
@@ -108,9 +108,8 @@ schema.set('toJSON', {
 
 schema.methods.generateMintTransactionData = function generateMintTransactionData() {
 
-  // @TODO: sort out proper provider ID functionality
   const additionalData = codexRecordService.encodeAdditionalData([
-    '1', // providerId
+    process.env.METADATA_PROVIDER_ID, // providerId
     this.id, // providerMetadataId
   ])
 
@@ -135,9 +134,8 @@ schema.methods.generateModifyMetadataHashesTransactionData = function generateMo
     throw new Error('generateModifyMetadataHashesTransactionData could not be called because a pendingUpdate was not specified.')
   }
 
-  // @TODO: sort out proper provider ID functionality
   const additionalData = codexRecordService.encodeAdditionalData([
-    '1', // providerId
+    process.env.METADATA_PROVIDER_ID, // providerId
     this.id, // providerMetadataId
   ])
 

--- a/src/models/codex-record-modified-event.js
+++ b/src/models/codex-record-modified-event.js
@@ -122,7 +122,7 @@ schema.virtual('changedData').get(function getChangedData() {
   // if this instance was created as a result of processing a Modified event for
   //  a third-party hosted Record, none of the non-hash values will exist
   //
-  // @NOTE: this can't just use the blockchain-provided hases since we wouldn't
+  // @NOTE: this can't just use the blockchain-provided hashes since we wouldn't
   //  be discern between images, files, and mainImage file hashes
   if (!this.provider || this.provider.id !== process.env.METADATA_PROVIDER_ID) {
     return null

--- a/src/models/codex-record-modified-event.js
+++ b/src/models/codex-record-modified-event.js
@@ -17,10 +17,14 @@ const schema = new mongoose.Schema({
     lowercase: true,
     // @TODO: add validators to make sure only proper addresses can be specified
   },
+  provider: {
+    default: null,
+    ref: 'Provider',
+    type: mongoose.Schema.Types.ObjectId,
+  },
   providerId: {
-    type: String, // @TODO: use mongoose.Schema.Types.ObjectId?
+    type: 'String',
     required: true,
-    // ref: 'Provider', // @TODO: link this to a Provider model?
   },
   providerMetadataId: {
     type: String,
@@ -116,10 +120,11 @@ const schema = new mongoose.Schema({
 schema.virtual('changedData').get(function getChangedData() {
 
   // if this instance was created as a result of processing a Modified event for
-  //  a third-party hosted Record, none of the non-hash value will exist
+  //  a third-party hosted Record, none of the non-hash values will exist
   //
-  // @TODO: sort out proper provider ID functionality
-  if (this.providerId !== '1') {
+  // @NOTE: this can't just use the blockchain-provided hases since we wouldn't
+  //  be discern between images, files, and mainImage file hashes
+  if (!this.provider || this.provider.id !== process.env.METADATA_PROVIDER_ID) {
     return null
   }
 
@@ -181,9 +186,9 @@ schema.pre('findOne', makeQueryAddressesCaseInsensitive)
 schema.pre('findOneAndRemove', makeQueryAddressesCaseInsensitive)
 schema.pre('findOneAndUpdate', makeQueryAddressesCaseInsensitive)
 
-// always get images, files, and pendingUpdates
+// always get images, files, pendingUpdates, etc
 function populate(next) {
-  this.populate('newMainImage newImages newFiles oldMainImage oldImages oldFiles')
+  this.populate('provider newMainImage newImages newFiles oldMainImage oldImages oldFiles')
   next()
 }
 

--- a/src/models/codex-record.js
+++ b/src/models/codex-record.js
@@ -48,9 +48,8 @@ const schema = new mongoose.Schema({
     type: String,
   }],
   providerId: {
-    type: String, // @TODO: use mongoose.Schema.Types.ObjectId?
+    type: String,
     default: null,
-    // ref: 'Provider', // @TODO: link this to a Provider model?
   },
   providerMetadataId: {
     type: String,
@@ -86,6 +85,11 @@ const schema = new mongoose.Schema({
     permissions: ['owner'],
     // @TODO: add validators to make sure only proper addresses can be specified
   }],
+  provider: {
+    default: null,
+    ref: 'Provider',
+    type: mongoose.Schema.Types.ObjectId,
+  },
   metadata: {
     default: null,
     permissions: ['approved'],
@@ -188,9 +192,10 @@ schema.pre('findOne', makeQueryAddressesCaseInsensitive)
 schema.pre('findOneAndRemove', makeQueryAddressesCaseInsensitive)
 schema.pre('findOneAndUpdate', makeQueryAddressesCaseInsensitive)
 
-// always get provenance & metadata
+// always get provenance & metadata, etc
 function populate(next) {
   this.populate('metadata')
+  this.populate('provider')
   this.populate({
     path: 'provenance',
     options: {

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -4,9 +4,10 @@ import CodexRecordModifiedEvent from './codex-record-modified-event'
 import CodexRecordMetadata from './codex-record-metadata'
 import BlockchainEvent from './blockchain-event'
 import CodexRecordFile from './codex-record-file'
-import Transaction from './transaction'
 import CodexRecord from './codex-record'
+import Transaction from './transaction'
 import Giveaway from './giveaway'
+import Provider from './provider'
 import Gallery from './gallery'
 import User from './user'
 import Job from './job'
@@ -21,6 +22,7 @@ export default {
   Transaction,
   CodexRecord,
   Giveaway,
+  Provider,
   Gallery,
   User,
   Job,

--- a/src/models/provider.js
+++ b/src/models/provider.js
@@ -1,0 +1,64 @@
+import shortid from 'shortid'
+import mongoose from 'mongoose'
+
+import logger from '../services/logger'
+import mongooseService from '../services/mongoose'
+
+const schemaOptions = {
+  timestamps: true, // let mongoose handle the createdAt and updatedAt fields
+}
+
+const schema = new mongoose.Schema({
+  _id: {
+    type: String,
+    required: true,
+    default: shortid.generate,
+  },
+  name: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+    default: null,
+  },
+  metadataUrl: {
+    type: String,
+    default: null,
+  },
+}, schemaOptions)
+
+schema.set('toJSON', {
+  virtuals: true,
+  versionKey: false,
+  transform(document, transformedDocument) {
+
+    // remove some mongo-specific keys that aren't necessary to send in
+    //  responses
+    delete transformedDocument._id
+
+    return transformedDocument
+
+  },
+})
+
+schema.set('toObject', {
+  virtuals: true,
+})
+
+const Provider = mongooseService.codexRegistry.model('Provider', schema)
+
+// create a Provider for this API if it doesn't exist yet...
+const newProviderOptions = {
+  setDefaultsOnInsert: true,
+  upsert: true,
+}
+
+Provider.findByIdAndUpdate(process.env.METADATA_PROVIDER_ID, {}, newProviderOptions)
+  .then((existingRecord) => {
+    if (!existingRecord) {
+      logger.warn(`Provider with id "${process.env.METADATA_PROVIDER_ID}" did not exist, but one was created automatically.`)
+    }
+  })
+
+export default Provider

--- a/src/routes/admin/giveaway/create.js
+++ b/src/routes/admin/giveaway/create.js
@@ -1,10 +1,10 @@
-import config from '../../config'
-import models from '../../models'
+import config from '../../../config'
+import models from '../../../models'
 
 export default {
 
   method: 'post',
-  path: '/giveaways?',
+  path: '/admin/giveaways?',
 
   requireAuthentication: true,
 

--- a/src/routes/admin/provider/create.js
+++ b/src/routes/admin/provider/create.js
@@ -1,0 +1,36 @@
+import Joi from 'joi'
+import RestifyErrors from 'restify-errors'
+
+import models from '../../../models'
+
+export default {
+
+  method: 'post',
+  path: '/admin/providers?',
+
+  requireAuthentication: true,
+
+  // @TODO: add admin authentication and allow this in all environments
+  restrictToEnvironments: [
+    'development',
+  ],
+
+  parameters: Joi.object().keys({
+    _id: Joi.string(),
+    name: Joi.string().required(),
+    metadataUrl: Joi.string().allow(null),
+    description: Joi.string().allow(null),
+  }).rename('id', '_id'),
+
+  handler(request, response) {
+
+    return new models.Provider(request.parameters).save()
+      .catch((error) => {
+        if (error.code === 11000) {
+          throw new RestifyErrors.ConflictError(`Provider with id "${request.parameters._id}" already exists.`)
+        }
+      })
+
+  },
+
+}

--- a/src/routes/user/gallery/create.js
+++ b/src/routes/user/gallery/create.js
@@ -13,7 +13,7 @@ export default {
 
   requireAuthentication: true,
 
-  // @TODO: add admin authentication and allow this in all environments
+  // @TODO: allow this in all environments when user galleries are implemented
   restrictToEnvironments: [
     'development',
   ],

--- a/src/routes/user/gallery/delete.js
+++ b/src/routes/user/gallery/delete.js
@@ -9,7 +9,7 @@ export default {
 
   requireAuthentication: true,
 
-  // @TODO: add admin authentication and allow this in all environments
+  // @TODO: allow this in all environments when user galleries are implemented
   restrictToEnvironments: [
     'development',
   ],

--- a/src/routes/user/gallery/find.js
+++ b/src/routes/user/gallery/find.js
@@ -7,6 +7,11 @@ export default {
 
   requireAuthentication: true,
 
+  // @TODO: allow this in all environments when user galleries are implemented
+  restrictToEnvironments: [
+    'development',
+  ],
+
   handler(request, response) {
 
     const conditions = {

--- a/src/routes/user/gallery/update.js
+++ b/src/routes/user/gallery/update.js
@@ -14,7 +14,7 @@ export default {
 
   requireAuthentication: true,
 
-  // @TODO: add admin authentication and allow this in all environments
+  // @TODO: allow this in all environments when user galleries are implemented
   restrictToEnvironments: [
     'development',
   ],

--- a/src/services/codex-record.js
+++ b/src/services/codex-record.js
@@ -45,7 +45,7 @@ export default {
               return codexRecord
             }
 
-            // assocaite the Record with this provider
+            // associate the Record with this provider
             codexRecord.provider = provider
 
             // if we don't host the metadata for this provider, we can stop here
@@ -67,7 +67,7 @@ export default {
 
                 codexRecordMetadata.codexRecordTokenId = codexRecord.tokenId
 
-                // @TODO: maybe verify hases here? e.g.:
+                // @TODO: maybe verify hashes here? e.g.:
                 // codexRecordMetadata.nameHash === codexRecord.nameHash
                 // codexRecordMetadata.descriptionHash === codexRecord.descriptionHash
 
@@ -242,7 +242,7 @@ export default {
 
         const [pendingUpdateToCommit] = codexRecord.metadata.pendingUpdates.splice(pendingUpdateToCommitIndex, 1)
 
-        // @TODO: maybe verify hases here? e.g.:
+        // @TODO: maybe verify hashes here? e.g.:
         // pendingUpdateToCommit.nameHash === nameHash
         // pendingUpdateToCommit.descriptionHash === descriptionHash
 

--- a/src/services/codex-record.js
+++ b/src/services/codex-record.js
@@ -1,5 +1,6 @@
 import { contracts } from '@codex-protocol/ethereum-service'
 
+import logger from './logger'
 import config from '../config'
 import models from '../models'
 import SocketService from './socket'
@@ -15,6 +16,8 @@ export default {
   //  the info emitted by the Minted event
   confirmMint(tokenId, additionalData, transactionHash) {
 
+    const [providerId = null, providerMetadataId = null] = this.decodeAdditionalData(additionalData)
+
     return models.CodexRecord.findById(tokenId)
       .then((codexRecord) => {
 
@@ -22,34 +25,59 @@ export default {
           throw new Error(`Could not confirm CodexRecord with tokenId ${tokenId} because it does not exist.`)
         }
 
-        const [providerId, providerMetadataId] = this.decodeAdditionalData(additionalData)
-
-        codexRecord.providerMetadataId = providerMetadataId
-        codexRecord.providerId = providerId
-
-        // @TODO: sort out proper provider ID functionality
-        if (codexRecord.providerId !== '1') {
-          return codexRecord
+        if (codexRecord.providerId !== null) {
+          throw new Error(`Could not confirm CodexRecord with tokenId ${tokenId} because it is already associated with providerId ${codexRecord.providerId}.`)
         }
 
-        return models.CodexRecordMetadata.findById(providerMetadataId)
-          .then((codexRecordMetadata) => {
+        if (codexRecord.providerMetadataId !== null) {
+          throw new Error(`Could not confirm CodexRecord with tokenId ${tokenId} because it is already associated with providerMetadataId ${codexRecord.providerMetadataId}.`)
+        }
 
-            if (!codexRecordMetadata) {
-              throw new Error(`Could not confirm CodexRecord with tokenId ${codexRecord.tokenId} because metadata with id ${providerMetadataId} does not exist.`)
+        codexRecord.providerId = providerId
+        codexRecord.providerMetadataId = providerMetadataId
+
+        return models.Provider.findById(providerId)
+          .then((provider) => {
+
+            // if no provider was found, we can stop here
+            if (!provider) {
+              logger.warn(`Found unknown providerId "${providerId}" for CodexRecord with tokenId ${tokenId}`)
+              return codexRecord
             }
 
-            codexRecordMetadata.codexRecordTokenId = codexRecord.tokenId
+            // assocaite the Record with this provider
+            codexRecord.provider = provider
 
-            // @TODO: maybe verify hases here? e.g.:
-            // codexRecordMetadata.nameHash === codexRecord.nameHash
-            // codexRecordMetadata.descriptionHash === codexRecord.descriptionHash
+            // if we don't host the metadata for this provider, we can stop here
+            if (provider.id !== process.env.METADATA_PROVIDER_ID) {
+              return codexRecord
+            }
 
-            return codexRecordMetadata.save()
-              .then(() => {
-                codexRecord.metadata = codexRecordMetadata
-                return codexRecord
+            // otherwise find the metadata and associate with this Record
+            return models.CodexRecordMetadata.findById(providerMetadataId)
+              .then((codexRecordMetadata) => {
+
+                if (!codexRecordMetadata) {
+                  throw new Error(`Could not confirm CodexRecord with tokenId ${codexRecord.tokenId} because metadata with id ${providerMetadataId} does not exist.`)
+                }
+
+                if (codexRecordMetadata.codexRecordTokenId !== null) {
+                  throw new Error(`Could not confirm CodexRecord with tokenId ${codexRecord.tokenId} because metadata with id ${providerMetadataId} is already associated with tokenId ${codexRecordMetadata.codexRecordTokenId}.`)
+                }
+
+                codexRecordMetadata.codexRecordTokenId = codexRecord.tokenId
+
+                // @TODO: maybe verify hases here? e.g.:
+                // codexRecordMetadata.nameHash === codexRecord.nameHash
+                // codexRecordMetadata.descriptionHash === codexRecord.descriptionHash
+
+                return codexRecordMetadata.save()
+                  .then(() => {
+                    codexRecord.metadata = codexRecordMetadata
+                    return codexRecord
+                  })
               })
+
           })
       })
 
@@ -58,8 +86,7 @@ export default {
       })
 
       .then((codexRecord) => {
-        // @TODO: sort out proper provider ID functionality
-        if (codexRecord.providerId === '1') {
+        if (codexRecord.provider && codexRecord.provider.id === process.env.METADATA_PROVIDER_ID) {
           codexRecord.setLocals({ userAddress: codexRecord.ownerAddress })
           SocketService.emitToAddress(codexRecord.ownerAddress, 'codex-record:minted', codexRecord)
         }
@@ -111,12 +138,12 @@ export default {
     transactionHash,
   ) {
 
-    const [providerId, providerMetadataId] = this.decodeAdditionalData(additionalData)
+    const [providerId = null, providerMetadataId = null] = this.decodeAdditionalData(additionalData)
 
     const findCodexRecordConditions = {
-      providerId,
-      _id: tokenId,
       providerMetadataId,
+      _id: tokenId,
+      providerId,
     }
 
     const newCodexRecordModifiedEvent = new models.CodexRecordModifiedEvent({
@@ -139,6 +166,10 @@ export default {
 
         if (!codexRecord) {
           throw new Error(`Could not modify CodexRecord with tokenId ${tokenId} because it does not exist.`)
+        }
+
+        if (codexRecord.provider) {
+          newCodexRecordModifiedEvent.provider = codexRecord.provider
         }
 
         newCodexRecordModifiedEvent.oldNameHash = codexRecord.nameHash
@@ -178,8 +209,7 @@ export default {
 
       .then((codexRecord) => {
 
-        // @TODO: sort out proper provider ID functionality
-        if (codexRecord.providerId !== '1') {
+        if (!codexRecord.provider || codexRecord.provider.id !== process.env.METADATA_PROVIDER_ID) {
           return codexRecord
         }
 
@@ -250,8 +280,7 @@ export default {
           })
       })
       .then((codexRecord) => {
-        // @TODO: sort out proper provider ID functionality
-        if (codexRecord.providerId === '1') {
+        if (codexRecord.provider && codexRecord.provider.id === process.env.METADATA_PROVIDER_ID) {
           codexRecord.setLocals({ userAddress: codexRecord.ownerAddress })
           SocketService.emitToAddress(codexRecord.ownerAddress, 'codex-record:modified', codexRecord)
         }
@@ -298,8 +327,8 @@ export default {
       })
 
       .then((codexRecord) => {
-        // @TODO: sort out proper provider ID functionality
-        if (codexRecord.providerId === '1') {
+
+        if (codexRecord.provider && codexRecord.provider.id === process.env.METADATA_PROVIDER_ID) {
           // @NOTE: normally we'd want to use
           //  codexRecord.setLocals({ userAddress: oldOwnerAddress }) when
           //  constructing the JSON for the old owner... but if we do that then
@@ -313,7 +342,9 @@ export default {
           SocketService.emitToAddress(newOwnerAddress, 'codex-record:transferred:new-owner', responseJSON)
           SocketService.emitToAddress(oldOwnerAddress, 'codex-record:transferred:old-owner', responseJSON)
         }
+
         return codexRecord
+
       })
 
   },
@@ -348,8 +379,7 @@ export default {
       })
 
       .then((codexRecord) => {
-        // @TODO: sort out proper provider ID functionality
-        if (codexRecord.providerId === '1') {
+        if (codexRecord.provider && codexRecord.provider.id === process.env.METADATA_PROVIDER_ID) {
           codexRecord.setLocals({ userAddress: codexRecord.ownerAddress })
           SocketService.emitToAddress(ownerAddress, 'codex-record:destroyed', codexRecord)
         }
@@ -375,9 +405,8 @@ export default {
       })
 
       .then((codexRecord) => {
-        // @TODO: sort out proper provider ID functionality
-        if (codexRecord.providerId === '1') {
 
+        if (codexRecord.provider && codexRecord.provider.id === process.env.METADATA_PROVIDER_ID) {
           const ownerResponse = codexRecord.setLocals({ userAddress: codexRecord.ownerAddress }).toJSON()
           const approvedResponse = codexRecord.setLocals({ userAddress: codexRecord.approvedAddress }).toJSON()
 
@@ -396,7 +425,9 @@ export default {
             SocketService.emitToAddress(codexRecord.approvedAddress, 'codex-record:address-approved:approved', approvedResponse)
           }
         }
+
         return codexRecord
+
       })
 
   },
@@ -418,6 +449,7 @@ export default {
       .toString('hex')
 
     return `0x${hexString}`
+
   },
 
   // this decodes additionalData strings when a Minted or Modified event is


### PR DESCRIPTION
This PR add a new `Provider` model and replaces the hardcoded `'1'` that was used to denote codex-hosted metadata.

See also:
[web.codex-viewer#53](https://github.com/codex-protocol/web.codex-viewer/pull/53)
[contract.codex-registry#36](https://github.com/codex-protocol/contract.codex-registry/pull/36)